### PR TITLE
feat : /token/isValid API 추가 (Access Token 유효성 boolean 반환)

### DIFF
--- a/src/main/java/com/mindsync/mindsync/controller/TokenController.java
+++ b/src/main/java/com/mindsync/mindsync/controller/TokenController.java
@@ -1,0 +1,35 @@
+package com.mindsync.mindsync.controller;
+
+import com.mindsync.mindsync.dto.ResponseDto;
+import com.mindsync.mindsync.jwt.JWTUtil;
+import com.mindsync.mindsync.utils.ResponseStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/token")
+public class TokenController {
+    private final JWTUtil jwtUtil;
+
+    public TokenController(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @GetMapping("/isValid")
+    public ResponseDto<Boolean> isTokenExpired(@RequestHeader("Authorization") String header) {
+        if (header == null || !header.startsWith("Bearer ")) {
+            return new ResponseDto<>(ResponseStatus.FAILURE, "Authorization header가 없거나 잘못되었습니다.", false);
+        }
+        String token = header.substring(7);
+        boolean isValid;
+        try {
+            boolean expired = jwtUtil.isExpired(token);
+            isValid = !expired;
+        } catch (Exception e) {
+            isValid = false;
+        }
+        return new ResponseDto<>(ResponseStatus.SUCCESS, "토큰 유효성 검사 완료되었습니다.", isValid);
+    }
+}


### PR DESCRIPTION
클라이언트 요청으로 Access Token 유효성 검사 API 추가
유효한 토큰 : true 반환
만료/에러 : false 반환
ResponseDto로 래핑하여 응답하도록 함

👩‍💻 @femmefatalehaein 프론트 연동 시 확인 부탁드립니다.